### PR TITLE
[Feat/user-forgot-pw] 유저 비밀번호 찾기 - 이메일인증, 유저 swagger-ui 설명문 추가, wishlist 로직 변경

### DIFF
--- a/app/orders/serializers.py
+++ b/app/orders/serializers.py
@@ -15,7 +15,7 @@ class OrderListSerializer(serializers.ModelSerializer):  # type: ignore
 
     class Meta:
         model = Order
-        exclude = ("user",)
+        exclude = ("user", "user_coupon")
         read_only_fields = ["order_id", "status", "sale_price", "total_price", "return_date"]
 
 

--- a/app/users/serializers.py
+++ b/app/users/serializers.py
@@ -58,11 +58,26 @@ class UserInfoModifySerializer(serializers.ModelSerializer):
 class VerificationCodeSerializer(serializers.Serializer):
     email = serializers.EmailField()
     code = serializers.CharField(max_length=6)
+    verification_type = serializers.CharField(max_length=15)
+    user_id = serializers.CharField(max_length=15, required=False)
 
     def validate(self, data):
-        email = data.get("email")
-        code = data.get("code")
-        verification_code = cache.get(f"{email}-verify_code")
+        email = data["email"]
+        code = data["code"]
+        verification_type = data["verification_type"]
+
+        # 캐시에서 검색하는 키를 설정
+        if verification_type == "signup":
+            cache_key = f"{email}-verify_code"
+        elif verification_type == "forgot_password" and "user_id" in data:
+            user_id = data["user_id"]
+            cache_key = f"{user_id}-{email}-verify_code"
+        else:
+            raise serializers.ValidationError("Invalid verification type")
+
+        # 캐시에서 검색한 코드 가져오기
+        verification_code = cache.get(cache_key)
+
         if verification_code is None:
             raise serializers.ValidationError("Email Verification time has expired.")
         if code != verification_code:  # 인증코드 일치 여부 확인
@@ -73,3 +88,27 @@ class VerificationCodeSerializer(serializers.Serializer):
 
 class EmailSerializer(serializers.Serializer):
     email = serializers.EmailField(required=True, max_length=30)
+
+    def validate(self, data):
+        email = data.get("email", "")
+        if not email:
+            raise serializers.ValidationError("이메일을 입력해주세요.")
+        elif User.objects.filter(email=email).exists():
+            raise serializers.ValidationError("이미 가입된 이메일입니다.")
+        return data
+
+class ForgotPasswordSerializer(serializers.Serializer):
+    email = serializers.EmailField(max_length=30)
+    user_id = serializers.CharField(max_length=15)
+
+    def validate(self, data):
+        email = data.get("email")
+        if not email:
+            raise serializers.ValidationError("이메일을 입력해주세요.")
+        user_id = data.get("user_id")
+        if not user_id:
+            raise serializers.ValidationError("아이디를 입력해주세요.")
+        user = User.objects.filter(email=email, user_id=user_id).first()
+        if not user:
+            raise serializers.ValidationError("입력한 아이디와 이메일 인증정보가 일치하지 않습니다.")
+        return data

--- a/app/users/serializers.py
+++ b/app/users/serializers.py
@@ -97,6 +97,7 @@ class EmailSerializer(serializers.Serializer):
             raise serializers.ValidationError("이미 가입된 이메일입니다.")
         return data
 
+
 class ForgotPasswordSerializer(serializers.Serializer):
     email = serializers.EmailField(max_length=30)
     user_id = serializers.CharField(max_length=15)

--- a/app/users/urls.py
+++ b/app/users/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path("simple/jwt_verify_token", TokenVerifyView.as_view(), name="token_verify"),
     path("signup/", views.Signup.as_view(), name="signup"),
     path("info/", views.UserDetailView.as_view(), name="user_detail"),
-    path("email-verify/send/verify-code/", views.SendVerificationCodeView.as_view(), name="send_verify_code"),
+    path("email-verify/send/", views.SendVerificationCodeView.as_view(), name="send_verify_code"),
+    path("email-verify/forgot-password/", views.ForgotPasswordView.as_view(), name="forgot_password"),
     path("email-verify/", views.VerifyCodeView.as_view(), name="email_verify"),
 ]

--- a/app/users/views.py
+++ b/app/users/views.py
@@ -31,7 +31,7 @@ class Signup(APIView):
     @extend_schema(
         request=serializers.UserSignUpSerializer,
         responses=serializers.UserSignUpSerializer,
-        description="회원 가입시 입력한 데이터를 검증하고 검증이 되면 유저에 대한 정보를 데이터 베이스에 저장함."
+        description="회원 가입시 입력한 데이터를 검증하고 검증이 되면 유저에 대한 정보를 데이터 베이스에 저장함.",
     )
     def post(self, request: Request) -> Response:
         user_data = request.data
@@ -51,7 +51,7 @@ class SendVerificationCodeView(APIView):
 
     @extend_schema(
         request=serializers.EmailSerializer,
-        description="유저가 회원가입시 이메일을 입력하면 인증을 진행해야하는데, 입력한 이메일을 검증 후에 인증에 쓰일 코드를 이메일로 보내줌."
+        description="유저가 회원가입시 이메일을 입력하면 인증을 진행해야하는데, 입력한 이메일을 검증 후에 인증에 쓰일 코드를 이메일로 보내줌.",
     )
     def post(self, request: Request) -> Response:
         serializer = serializers.EmailSerializer(data=request)
@@ -81,13 +81,13 @@ class ForgotPasswordView(APIView):
 
     @extend_schema(
         request=serializers.ForgotPasswordSerializer,
-        description="비밀번호 찾기 시 입력한 아이디와 이메일을 검증하고 이메일로 인증코드를 보내도록 함."
+        description="비밀번호 찾기 시 입력한 아이디와 이메일을 검증하고 이메일로 인증코드를 보내도록 함.",
     )
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         serializer = serializers.ForgotPasswordSerializer(data=request.data)
         if serializer.is_valid():
-            email = serializer.validated_data.get('email')
-            user_id = serializer.validated_data.get('user_id')
+            email = serializer.validated_data.get("email")
+            user_id = serializer.validated_data.get("user_id")
             verification_code = get_random_string(length=6)
             message = f"""
                         안녕하세요. DogGo의 계정 {user_id}의 비밀번호 찾기 시 인증 코드로 입력해야 할 인증 코드는 아래와 같습니다.
@@ -103,6 +103,7 @@ class ForgotPasswordView(APIView):
             email_message.send()  # 이메일 전송
             cache.set(f"{user_id}-{email}-verify_code", verification_code, timeout=180)
             return Response({"msg": "verification code has been sent to email."}, status=status.HTTP_200_OK)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 class VerifyCodeView(APIView):
@@ -111,7 +112,7 @@ class VerifyCodeView(APIView):
 
     @extend_schema(
         request=serializers.VerificationCodeSerializer,
-        description="회원가입 또는 비밀번호 찾기에서 이메일 인증 시 이메일과 인증 코드를 확인하여 인증여부를 응답으로 보내줌."
+        description="회원가입 또는 비밀번호 찾기에서 이메일 인증 시 이메일과 인증 코드를 확인하여 인증여부를 응답으로 보내줌.",
     )
     def post(self, request: Request) -> Response:
         serializer = serializers.VerificationCodeSerializer(data=request.data)
@@ -198,7 +199,7 @@ class UserDetailView(APIView):
     @extend_schema(
         request=serializers.UserInfoSerializer,
         responses=serializers.UserInfoSerializer,
-        description="유저의 내정보 가져오기 기능"
+        description="유저의 내정보 가져오기 기능",
     )
     def get(self, request: Request) -> Response:
         user = User.objects.get(id=request.user.id)  # type: ignore
@@ -233,9 +234,7 @@ class UserDetailView(APIView):
         serializer.save()
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    @extend_schema(
-        description="회원탈퇴 요청을 처리하는 뷰, 데이터를 바로지우지않고 상태를 변경함."
-    )
+    @extend_schema(description="회원탈퇴 요청을 처리하는 뷰, 데이터를 바로지우지않고 상태를 변경함.")
     def delete(self, request: Request) -> Response:
         # 회원탈퇴 요청이 들어오면 상태를 False로 바꿔 탈퇴예정임을 나타내고
         # del_req_time 을 요청이 들어온 현재시간으로 세팅한다.

--- a/app/wishlist/tests.py
+++ b/app/wishlist/tests.py
@@ -46,7 +46,8 @@ class WishlistTestCase(APITestCase):
         response = self.client.post(url, data, headers={"Authorization": f"Bearer {self.token}"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual("already added", response.data["msg"])
+        self.assertFalse(response.data["status"])
+        self.assertEqual(response.data["product"], self.product1.id)
 
         # 이미 위시리스트에 넣었다가 취소하고 다시 위시리스트에 추가하는 경우 테스트
         wishlist = Wishlist.objects.get(user_id=self.user.id, product_id=self.product1.id)
@@ -111,20 +112,20 @@ class WishlistDetailTestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_delete_product_detail(self) -> None:
+    def test_put_wishlist_detail(self) -> None:
         url = reverse("wishlist_detail", kwargs={"wishlist_id": self.wishlist.id})
-        response = self.client.delete(url, headers={"Authorization": f"Bearer {self.token}"})
+        response = self.client.put(url, headers={"Authorization": f"Bearer {self.token}"})
         deleted_wishlist = Wishlist.objects.get(user_id=self.user.id, product_id=self.product.id)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(deleted_wishlist.status)
 
-        response = self.client.delete(url, headers={"Authorization": f"Bearer {self.token}"})
+        response = self.client.put(url, headers={"Authorization": f"Bearer {self.token}"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["msg"], "already deleted")
 
         url = reverse("wishlist_detail", kwargs={"wishlist_id": 919919191911})
-        response = self.client.get(url, headers={"Authorization": f"Bearer {self.token}"})
+        response = self.client.put(url, headers={"Authorization": f"Bearer {self.token}"})
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/app/wishlist/views.py
+++ b/app/wishlist/views.py
@@ -43,9 +43,7 @@ class WishlistView(APIView):
                 user_id=request.user.id, product_id=serializer.validated_data["product"]
             ).first()
             if check_wishlist:
-                if check_wishlist.status:
-                    return Response({"msg": "already added"}, status=status.HTTP_200_OK)
-                check_wishlist.status = True
+                check_wishlist.status = not check_wishlist.status
                 check_wishlist.save()
                 serializer = CreateWishlistSerializer(check_wishlist)
                 return Response(serializer.data, status=status.HTTP_200_OK)
@@ -64,7 +62,7 @@ class WishlistDetailView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     # 위시리스트 삭제하기
-    def delete(self, request: Request, wishlist_id: int) -> Response:
+    def put(self, request: Request, wishlist_id: int) -> Response:
         wishlist = get_object_or_404(Wishlist, id=wishlist_id, user_id=request.user.id)
         if not wishlist.status:
             return Response({"msg": "already deleted"}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Feat

- ForgotPasswordSerializer: 이메일과 유저의 아이디를 받아서 인증정보를 검증
- 엔드포인트 추가

## Fix
- VerificationCodeSerializer에서 입력받은 정보를 바탕으로 검증하는데 타입에 따라서 회원가입과 비밀번호 찾기에 필요한 데이터를 받도록 설정

- 기존의 view에서 하던 검증을 EmailSerializer에서 처리하도록 변경
- 엔드포인트 정리
- 각 메서드에 대해 설명문 추가